### PR TITLE
Prevent specific snippets from being cached

### DIFF
--- a/client-side/history.ajax.js
+++ b/client-side/history.ajax.js
@@ -9,10 +9,12 @@ var findSnippets = function () {
 	var result = [];
 	$('[id^="snippet-"]').each(function () {
 		var $el = $(this);
-		result.push({
-			id: $el.attr('id'),
-			html: $el.html()
-		});
+		if (!$el.is('[data-history-nocache]')) {
+			result.push({
+				id: $el.attr('id'),
+				html: $el.html()
+			});
+		}
 	});
 	return result;
 };


### PR DESCRIPTION
This allows users to prevent snippets from being cached. It can be turned on using `data-history-nocache` attribute on a per-snippet basis (works only with `n:snippet` macro though as of current implementation in Nette).

Use case: we navigate to a product page using AJAX and add the product to cart, invalidating a snippet with cart contents. Pressing Back, the cart snippet is reloaded from cache, losing its actual content.
