### PR TITLE
OnResponseHandler: append presenter parameters to payload

### DIFF
--- a/src/OnResponseHandler.php
+++ b/src/OnResponseHandler.php
@@ -78,7 +78,7 @@ class OnResponseHandler
 					exit;
 				}
 			} elseif ($this->forwardHasHappened && !isset($payload->redirect)) {
-				$payload->redirect = $application->getPresenter()->link('this') . $this->fragment;
+				$payload->redirect = $application->getPresenter()->link('this', $application->getPresenter()->getParameters()) . $this->fragment;
 				$this->fragment = '';
 			}
 		}


### PR DESCRIPTION
Now when I use `$this->redirect('edit', ['id' => 5])` parameter `id` is lost and url changes to `/edit/` - without ID - so refreshing page breaks application. It would be much better to append current presenter's parameters to `$payload->redirect`
