### PR TITLE
Composer: removed dependency on nette/nette

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
 	],
 	"require": {
 		"php": ">=5.3.1",
-		"nette/nette": "~2.0"
+		"nette/application": "~2.0",
+		"nette/di": "~2.0",
+		"nette/http": "~2.0",
+		"nette/reflection": "~2.0"
 	},
 	"autoload": {
 		"classmap": ["src/"]


### PR DESCRIPTION
Hi, I've run into problem with composer packages versions at my application because of dependency on nette/nette package, and this little change of composer requirements would solve it.

It's related to & fixes #26 