### PR TITLE
client-side: fixed initial popstate callback being called on page load in Safari

### DIFF
--- a/client-side/history.ajax.js
+++ b/client-side/history.ajax.js
@@ -46,7 +46,7 @@ $.nette.ext('history', {
 			var state = e.originalEvent.state || this.initialState;
 			var initialPop = (!this.popped && initialUrl === state.href);
 			this.popped = true;
-			if (initialPop) {
+			if (initialPop || !e.state) {
 				return;
 			}
 			if (this.cache && state.ui) {


### PR DESCRIPTION
This fixes https://github.com/vojtech-dobes/history.nette.ajax.js/issues/29 based on http://stackoverflow.com/a/15897177/2278701
