### PR TITLE
JS: Support for iOS >=10

### DIFF
--- a/client-side/history.ajax.js
+++ b/client-side/history.ajax.js
@@ -1,7 +1,9 @@
 (function($, undefined) {
 
 // Is History API reliably supported? (based on Modernizr & PJAX)
-if (!(window.history && history.pushState && window.history.replaceState && !navigator.userAgent.match(/((iPod|iPhone|iPad).+\bOS\s+[1-4]|WebApps\/.+CFNetwork)/))) return;
+if (!(window.history && history.pushState && window.history.replaceState)) {
+	return;
+}
 
 $.nette.ext('redirect', false);
 


### PR DESCRIPTION
The script won't work on iOS 10.

The problem is a regexp when someone didn't expected iOS >9 (`... OS\s+[1-4] ...`).

And I think a condition can be removed nowadays (Q3 2016).

Isn't it? Thanks.