### PR TITLE
Fixing condition in popstate event handler

### DIFF
--- a/client-side/history.ajax.js
+++ b/client-side/history.ajax.js
@@ -48,7 +48,7 @@ $.nette.ext('history', {
 			var state = e.originalEvent.state || this.initialState;
 			var initialPop = (!this.popped && initialUrl === state.href);
 			this.popped = true;
-			if (initialPop || !e.state) {
+			if (initialPop || !e.originalEvent.state) {
 				return;
 			}
 			if (this.cache && state.ui) {


### PR DESCRIPTION
After merging #33, the popstate history stopped working at all. I believe the reason is that [`e.event` is always undefined on this line](https://github.com/vojtech-dobes/history.nette.ajax.js/blob/master/client-side/history.ajax.js#L51). `e` is jQuery Event Object, which does not contain property `event`. The proposed and linked solution on stack overflow however uses native JS event. Therefore, the correct condition should be using `e.originalEvent.state`:
```javascript
...
if (initialPop || !e.originalEvent.state) {
...
```